### PR TITLE
Use lidofinance fork for create-PR action

### DIFF
--- a/.github/actions/update_blst.yml
+++ b/.github/actions/update_blst.yml
@@ -34,7 +34,7 @@ jobs:
           cp ./blst/bindings/blst_aux.h ./blst-lib/;
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v4
+        uses: lidofinance/create-pull-request@v4
         branch: feature/recompile-blst-lib
 
   build-blst-macos:
@@ -51,5 +51,5 @@ jobs:
           cp ./blst/libblst.a   ./blst-lib/darwin/;
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: lidofinance/create-pull-request@v4
         branch: feature/recompile-blst-lib

--- a/.github/workflows/compile_blst.yml
+++ b/.github/workflows/compile_blst.yml
@@ -34,7 +34,7 @@ jobs:
           cp ./blst/bindings/blst_aux.h ./blst-lib/;
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v4
+        uses: lidofinance/create-pull-request@v4
         with:
           branch: feature/recompile-blst-lib
           title: 'Update blst lib.'


### PR DESCRIPTION
To make it consistent across organization and avoid problems with potential v4 tag changes
